### PR TITLE
ci: adiciona workflow para publicar wiki no GitHub

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,57 @@
+name: Publish Wiki
+
+on:
+  push:
+    paths:
+      - "docs/wiki/**"
+    branches:
+      - master
+      - develop
+      - "feat/**"
+  workflow_dispatch:
+
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Push wiki pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          WIKI_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git"
+
+          # Try to clone existing wiki; on failure (repo not yet init), start fresh
+          if git clone "$WIKI_URL" wiki-tmp 2>/dev/null; then
+            echo "Wiki cloned successfully"
+          else
+            echo "Wiki not initialized yet — creating fresh repo"
+            mkdir wiki-tmp
+            cd wiki-tmp
+            git init
+            git remote add origin "$WIKI_URL"
+            cd ..
+          fi
+
+          # Copy all wiki markdown files
+          cp docs/wiki/*.md wiki-tmp/
+
+          cd wiki-tmp
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .
+
+          # Commit only if there are changes
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "docs: atualiza wiki — $(date -u '+%Y-%m-%d')"
+            git push origin HEAD:master --force
+            echo "Wiki published successfully"
+          fi


### PR DESCRIPTION
## O que foi feito

Adiciona o workflow `publish-wiki.yml` que publica automaticamente os arquivos de `docs/wiki/` na GitHub Wiki do repositório.

## Como funciona

O workflow é disparado em qualquer push que altere arquivos em `docs/wiki/**` nas branches `master`, `develop` ou `feat/**`, e também pode ser disparado manualmente via `workflow_dispatch`.

O script:
1. Clona o repositório da wiki (ou inicia um novo se ainda não inicializado)
2. Copia todos os `.md` de `docs/wiki/`
3. Commit e force-push para `master` da wiki

## Páginas que serão publicadas

- `Home.md` — Documentação principal / índice
- `Visao.md` — Visão e filosofia do projeto
- `Arquitetura.md` — Arquitetura interna detalhada
- `Contribuindo.md` — Guia de contribuição
- `Fase-1-Fundacao.md` — Fundação, identidade, auth GitHub Copilot
- `Fase-2-Terminal.md` — Ferramentas de terminal e controle local
- `Fase-3-SSH.md` — Controle SSH e descoberta de rede
- `Fase-4-IoT.md` — MQTT, mDNS, HTTP, dispositivos IoT
- `Roadmap.md` — Roadmap das próximas fases

## Tipo de mudança

- [x] CI/CD — workflow novo, sem alteração de código de produção