### PR TITLE
fix(task): non-blocking checkpoint init + actionable retry exhaustion (#18)

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2072,6 +2072,8 @@ export class Task {
 								delaySeconds: 0,
 								failed: true, // Special flag to indicate retries exhausted
 								errorMessage: streamingFailedMessage,
+								actionableMessage:
+									"Try switching to a different model, reducing the context size by starting a new task, or waiting before retrying.",
 							}),
 						)
 					}
@@ -2345,24 +2347,19 @@ export class Task {
 		// Save checkpoint if this is the first API request
 		const isFirstRequest = this.messageStateHandler.getClineMessages().filter((m) => m.say === "api_req_started").length === 0
 
-		// Initialize checkpointManager first if enabled and it's the first request
+		// Initialize checkpoint manager in the background — do NOT block the task loop.
+		// commit() below handles lazy-init internally; errors surface as dismissible warnings in the webview.
 		if (
 			isFirstRequest &&
 			this.stateManager.getGlobalSettingsKey("enableCheckpointsSetting") &&
-			this.checkpointManager && // TODO REVIEW: may be able to implement a replacement for the 15s timer
+			this.checkpointManager &&
 			!this.taskState.checkpointManagerErrorMessage
 		) {
-			try {
-				await ensureCheckpointInitialized({ checkpointManager: this.checkpointManager })
-			} catch (error) {
+			ensureCheckpointInitialized({ checkpointManager: this.checkpointManager }).catch((error) => {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error"
 				Logger.error("Failed to initialize checkpoint manager:", errorMessage)
-				this.taskState.checkpointManagerErrorMessage = errorMessage // will be displayed right away since we saveClineMessages next which posts state to webview
-				HostProvider.window.showMessage({
-					type: ShowMessageType.ERROR,
-					message: `Checkpoint initialization timed out: ${errorMessage}`,
-				})
-			}
+				this.taskState.checkpointManagerErrorMessage = errorMessage
+			})
 		}
 
 		// Now, if it's the first request AND checkpoints are enabled AND tracker was successfully initialized,
@@ -3175,9 +3172,13 @@ export class Task {
 							delaySeconds: 0,
 							failed: true, // Special flag to indicate retries exhausted
 							errorMessage: noResponseErrorMessage,
+							actionableMessage:
+								"Try switching to a different model, reducing the context size by starting a new task, or waiting before retrying.",
 						}),
 					)
-					const askResult = await this.ask("api_req_failed", noResponseErrorMessage)
+					const exhaustedErrorMessage =
+						"All retry attempts exhausted: the provider returned no response. Try switching the model, reducing context size, or starting a new task."
+					const askResult = await this.ask("api_req_failed", exhaustedErrorMessage)
 					response = askResult.response
 					// Reset retry counter if user chooses to manually retry
 					if (response === "yesButtonClicked") {

--- a/src/shared/__tests__/combineErrorRetryMessages.test.ts
+++ b/src/shared/__tests__/combineErrorRetryMessages.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { combineErrorRetryMessages } from "../combineErrorRetryMessages"
+import type { ClineMessage } from "../ExtensionMessage"
+
+const mkMsg = (overrides: Partial<ClineMessage> & { say: ClineMessage["say"] }): ClineMessage =>
+	({
+		ts: Date.now(),
+		type: "say",
+		...overrides,
+	}) as ClineMessage
+
+describe("combineErrorRetryMessages", () => {
+	it("keeps only the latest error_retry in an ongoing retry sequence", () => {
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 2, maxAttempts: 3 }), ts: 3 }),
+			mkMsg({ say: "api_req_retried", ts: 4 }),
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 3, maxAttempts: 3 }), ts: 5 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		// api_req_retried messages pass through; only error_retry messages are consolidated
+		const retryMessages = result.filter((m) => m.say === "error_retry")
+		assert.equal(retryMessages.length, 1, "only the latest error_retry should remain")
+		const info = JSON.parse(retryMessages[0].text || "{}")
+		assert.equal(info.attempt, 3)
+	})
+
+	it("removes error_retry entirely when followed by a successful api_req_started", () => {
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({ say: "api_req_started", text: "{}", ts: 3 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		// error_retry is removed; api_req_retried and api_req_started pass through
+		assert.ok(
+			result.every((m) => m.say !== "error_retry"),
+			"error_retry should not appear in result",
+		)
+		assert.equal(result[result.length - 1].say, "api_req_started")
+	})
+
+	it("retains a failed:true error_retry even when followed by api_req_started", () => {
+		// failed:true means all retries were exhausted — it must remain visible in the UI
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({
+				say: "error_retry",
+				text: JSON.stringify({ attempt: 3, maxAttempts: 3, failed: true }),
+				ts: 3,
+			}),
+			mkMsg({ say: "api_req_started", text: "{}", ts: 4 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		const retryMessages = result.filter((m) => m.say === "error_retry")
+		assert.equal(retryMessages.length, 1)
+		const info = JSON.parse(retryMessages[0].text || "{}")
+		assert.equal(info.failed, true)
+	})
+
+	it("preserves actionableMessage field in a failed:true error_retry", () => {
+		const actionableMessage =
+			"Try switching to a different model, reducing the context size by starting a new task, or waiting before retrying."
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({
+				say: "error_retry",
+				text: JSON.stringify({
+					attempt: 3,
+					maxAttempts: 3,
+					failed: true,
+					actionableMessage,
+				}),
+				ts: 3,
+			}),
+		]
+		const result = combineErrorRetryMessages(messages)
+		const retryMsg = result.find((m) => m.say === "error_retry")
+		assert.ok(retryMsg, "error_retry message should be present")
+		const info = JSON.parse(retryMsg!.text || "{}")
+		assert.equal(info.actionableMessage, actionableMessage)
+	})
+
+	it("returns an empty array for an empty input", () => {
+		assert.deepEqual(combineErrorRetryMessages([]), [])
+	})
+
+	it("passes through unrelated messages unchanged", () => {
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "text", text: "hello", ts: 1 }),
+			mkMsg({ say: "api_req_started", text: "{}", ts: 2 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		assert.equal(result.length, 2)
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** #18

### Description

This PR fixes two related problems reported in #18:

**1. Checkpoint initialization blocks the task loop for up to 15 seconds**

`ensureCheckpointInitialized()` was being `await`ed at the start of the first API request, meaning the entire task loop blocked until checkpoint init completed (or timed out at 15s). This was a `// TODO REVIEW` leftover.

Fix: changed to fire-and-forget — errors are stored in `taskState.checkpointManagerErrorMessage` (already surfaced as a dismissible webview banner) instead of blocking execution. `commit()` already handles lazy-init internally, so the pre-init `await` was redundant AND harmful.

**2. No actionable guidance after all auto-retries are exhausted**

When the retry limit was hit (both for streaming-failed and no-response paths), the UI showed a generic error with no guidance on what the user could do next.

Fix: added `actionableMessage` to the `error_retry` payload on both exhausted paths with guidance to switch model / reduce context / start a new task. Updated `api_req_failed` ask message on the no-response exhausted path to also summarize the situation.

### Test Procedure

- Added 6 unit tests for `combineErrorRetryMessages` (paths that were previously untested: `failed: true`, `actionableMessage` field preservation).
- All 1313 tests pass (`npm run test:unit`).
- No regressions.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/fulviusguelfi/nexusai/blob/master/CONTRIBUTING.md)

### Screenshots

No UI screenshots required (backend + message payload changes). Terminal output: `1313 passing (1m)`.

### Additional Notes

The `api_req_retried` messages intentionally pass through `combineErrorRetryMessages` unchanged — only `error_retry` messages are consolidated. This is correctly reflected in the new tests.
