### PR TITLE
fix(task): non-blocking checkpoint init + actionable retry exhaustion…

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2072,6 +2072,8 @@ export class Task {
 								delaySeconds: 0,
 								failed: true, // Special flag to indicate retries exhausted
 								errorMessage: streamingFailedMessage,
+								actionableMessage:
+									"Try switching to a different model, reducing the context size by starting a new task, or waiting before retrying.",
 							}),
 						)
 					}
@@ -2345,24 +2347,19 @@ export class Task {
 		// Save checkpoint if this is the first API request
 		const isFirstRequest = this.messageStateHandler.getClineMessages().filter((m) => m.say === "api_req_started").length === 0
 
-		// Initialize checkpointManager first if enabled and it's the first request
+		// Initialize checkpoint manager in the background — do NOT block the task loop.
+		// commit() below handles lazy-init internally; errors surface as dismissible warnings in the webview.
 		if (
 			isFirstRequest &&
 			this.stateManager.getGlobalSettingsKey("enableCheckpointsSetting") &&
-			this.checkpointManager && // TODO REVIEW: may be able to implement a replacement for the 15s timer
+			this.checkpointManager &&
 			!this.taskState.checkpointManagerErrorMessage
 		) {
-			try {
-				await ensureCheckpointInitialized({ checkpointManager: this.checkpointManager })
-			} catch (error) {
+			ensureCheckpointInitialized({ checkpointManager: this.checkpointManager }).catch((error) => {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error"
 				Logger.error("Failed to initialize checkpoint manager:", errorMessage)
-				this.taskState.checkpointManagerErrorMessage = errorMessage // will be displayed right away since we saveClineMessages next which posts state to webview
-				HostProvider.window.showMessage({
-					type: ShowMessageType.ERROR,
-					message: `Checkpoint initialization timed out: ${errorMessage}`,
-				})
-			}
+				this.taskState.checkpointManagerErrorMessage = errorMessage
+			})
 		}
 
 		// Now, if it's the first request AND checkpoints are enabled AND tracker was successfully initialized,
@@ -3175,9 +3172,13 @@ export class Task {
 							delaySeconds: 0,
 							failed: true, // Special flag to indicate retries exhausted
 							errorMessage: noResponseErrorMessage,
+							actionableMessage:
+								"Try switching to a different model, reducing the context size by starting a new task, or waiting before retrying.",
 						}),
 					)
-					const askResult = await this.ask("api_req_failed", noResponseErrorMessage)
+					const exhaustedErrorMessage =
+						"All retry attempts exhausted: the provider returned no response. Try switching the model, reducing context size, or starting a new task."
+					const askResult = await this.ask("api_req_failed", exhaustedErrorMessage)
 					response = askResult.response
 					// Reset retry counter if user chooses to manually retry
 					if (response === "yesButtonClicked") {

--- a/src/shared/__tests__/combineErrorRetryMessages.test.ts
+++ b/src/shared/__tests__/combineErrorRetryMessages.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { combineErrorRetryMessages } from "../combineErrorRetryMessages"
+import type { ClineMessage } from "../ExtensionMessage"
+
+const mkMsg = (overrides: Partial<ClineMessage> & { say: ClineMessage["say"] }): ClineMessage =>
+	({
+		ts: Date.now(),
+		type: "say",
+		...overrides,
+	}) as ClineMessage
+
+describe("combineErrorRetryMessages", () => {
+	it("keeps only the latest error_retry in an ongoing retry sequence", () => {
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 2, maxAttempts: 3 }), ts: 3 }),
+			mkMsg({ say: "api_req_retried", ts: 4 }),
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 3, maxAttempts: 3 }), ts: 5 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		// api_req_retried messages pass through; only error_retry messages are consolidated
+		const retryMessages = result.filter((m) => m.say === "error_retry")
+		assert.equal(retryMessages.length, 1, "only the latest error_retry should remain")
+		const info = JSON.parse(retryMessages[0].text || "{}")
+		assert.equal(info.attempt, 3)
+	})
+
+	it("removes error_retry entirely when followed by a successful api_req_started", () => {
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({ say: "api_req_started", text: "{}", ts: 3 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		// error_retry is removed; api_req_retried and api_req_started pass through
+		assert.ok(
+			result.every((m) => m.say !== "error_retry"),
+			"error_retry should not appear in result",
+		)
+		assert.equal(result[result.length - 1].say, "api_req_started")
+	})
+
+	it("retains a failed:true error_retry even when followed by api_req_started", () => {
+		// failed:true means all retries were exhausted — it must remain visible in the UI
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({
+				say: "error_retry",
+				text: JSON.stringify({ attempt: 3, maxAttempts: 3, failed: true }),
+				ts: 3,
+			}),
+			mkMsg({ say: "api_req_started", text: "{}", ts: 4 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		const retryMessages = result.filter((m) => m.say === "error_retry")
+		assert.equal(retryMessages.length, 1)
+		const info = JSON.parse(retryMessages[0].text || "{}")
+		assert.equal(info.failed, true)
+	})
+
+	it("preserves actionableMessage field in a failed:true error_retry", () => {
+		const actionableMessage =
+			"Try switching to a different model, reducing the context size by starting a new task, or waiting before retrying."
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "error_retry", text: JSON.stringify({ attempt: 1, maxAttempts: 3 }), ts: 1 }),
+			mkMsg({ say: "api_req_retried", ts: 2 }),
+			mkMsg({
+				say: "error_retry",
+				text: JSON.stringify({
+					attempt: 3,
+					maxAttempts: 3,
+					failed: true,
+					actionableMessage,
+				}),
+				ts: 3,
+			}),
+		]
+		const result = combineErrorRetryMessages(messages)
+		const retryMsg = result.find((m) => m.say === "error_retry")
+		assert.ok(retryMsg, "error_retry message should be present")
+		const info = JSON.parse(retryMsg!.text || "{}")
+		assert.equal(info.actionableMessage, actionableMessage)
+	})
+
+	it("returns an empty array for an empty input", () => {
+		assert.deepEqual(combineErrorRetryMessages([]), [])
+	})
+
+	it("passes through unrelated messages unchanged", () => {
+		const messages: ClineMessage[] = [
+			mkMsg({ say: "text", text: "hello", ts: 1 }),
+			mkMsg({ say: "api_req_started", text: "{}", ts: 2 }),
+		]
+		const result = combineErrorRetryMessages(messages)
+		assert.equal(result.length, 2)
+	})
+})


### PR DESCRIPTION
… messages (#18)

- ensureCheckpointInitialized() is now fire-and-forget (no await) so the task loop no longer blocks up to 15s on checkpoint init at the first API request. commit() handles lazy-init internally; errors surface via taskState instead of an intrusive popup.
- Add actionableMessage to error_retry say (streaming-failed exhausted path) with guidance to switch model / reduce context / wait before retrying.
- Add actionableMessage + exhaustedErrorMessage to api_req_failed ask (no-response exhausted path) with the same guidance.
- Add 6 unit tests for combineErrorRetryMessages covering failed:true and actionableMessage preservation (all 1313 tests pass).

<!--
Thank you for contributing to NexusAI!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/fulviusguelfi/nexusai/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to NexusAI's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/fulviusguelfi/nexusai/blob/master/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
